### PR TITLE
Bug 959708 - [marionette-plugin-forms] setValue fails if element has not been seen before r=jugglinmike

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,6 +26,14 @@ Forms.prototype.fill = function(elem, value, done) {
 
 function setValue(elem, value, done) {
   elem.getAttribute('type', function(err, type) {
+    if (err) {
+      if (done) {
+        done(err);
+      } else {
+        throw err;
+      }
+      return;
+    }
 
     type = type.trim().toLowerCase();
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/mozilla-b2g/marionette-plugin-forms/issues"
   },
   "dependencies": {
-    "marionette-client": "~0.13.3"
+    "marionette-client": "~1.1.0"
   },
   "devDependencies": {
     "mozilla-download": "~0.2.1",

--- a/test/integration/fixtures/index.html
+++ b/test/integration/fixtures/index.html
@@ -10,6 +10,7 @@
       <input type="text" name="my-text-2" />
       <input type="date" name="my-date" />
       <input type="time" name="my-time" />
+      <input name="my-no-type" />
     </form>
   </body>
 </html>

--- a/test/integration/tests/index.js
+++ b/test/integration/tests/index.js
@@ -30,13 +30,17 @@ suite('Marionette Forms plugin', function() {
         client.findElement.bind(client, '[name="my-text-1"]'),
         client.findElement.bind(client, '[name="my-text-2"]'),
         client.findElement.bind(client, '[name="my-time"]'),
-        client.findElement.bind(client, '[name="my-date"]')
+        client.findElement.bind(client, '[name="my-date"]'),
+        client.findElement.bind(client, '[name="my-no-type"]'),
+        client.findElement.bind(client, '#invalid')
       ], function(err, results) {
         elems.form = results[0];
         elems.text1 = results[1];
         elems.text2 = results[2];
         elems.time = results[3];
         elems.date = results[4];
+        elems.noType = results[5];
+        elems.invalid = results[6];
         done();
       });
     });
@@ -78,6 +82,20 @@ suite('Marionette Forms plugin', function() {
             });
           });
         });
+        test('no [type]', function(done) {
+          client.forms.fill(elems.noType, 'Some text', function() {
+            elems.noType.getAttribute('value', function(err, val) {
+              assert.equal(val, 'Some text');
+              done();
+            });
+          });
+        });
+        test('invalid', function(done) {
+          client.forms.fill(elems.invalid, 'Some text', function(err) {
+            assert.ok(err, 'error is propagated');
+            done();
+          });
+        });
       });
     });
 
@@ -103,6 +121,15 @@ suite('Marionette Forms plugin', function() {
           client.forms.fill(elems.date, date);
           assert.equal(elems.date.getAttribute('value'), '1997-01-02');
         });
+        test('no [type]', function() {
+          client.forms.fill(elems.noType, 'Some text');
+          assert.equal(elems.noType.getAttribute('value'), 'Some text');
+        });
+        test('invalid', function() {
+          assert.throws(function() {
+            client.forms.fill(elems.invalid, 'Some text');
+          });
+        });
       });
 
       test('multiple elements', function() {
@@ -118,7 +145,9 @@ suite('Marionette Forms plugin', function() {
           'my-text-1': 'Some text',
           'my-text-2': 'Some more text',
           'my-time': date,
-          'my-date': date
+          'my-date': date,
+          'my-no-type': 'Lorem Ipsum',
+          'invalid': 'Should be bypassed'
         });
         assert.equal(
           elems.text1.getAttribute('value'),
@@ -140,6 +169,11 @@ suite('Marionette Forms plugin', function() {
           '1997-01-02',
           'Correct date input value'
         );
+        assert.equal(
+          elems.noType.getAttribute('value'),
+          'Lorem Ipsum',
+          'Correct input value even if missing [type]'
+        );
       });
     });
 
@@ -156,13 +190,16 @@ suite('Marionette Forms plugin', function() {
         'my-text-1': 'Some text',
         'my-text-2': 'Some more text',
         'my-time': date,
-        'my-date': date
+        'my-date': date,
+        'my-no-type': 'Lorem Ipsum',
+        'invalid': 'Should be bypassed'
       }, function() {
         async.parallel([
           elems.text1.getAttribute.bind(elems.text1, 'value'),
           elems.text2.getAttribute.bind(elems.text2, 'value'),
           elems.time.getAttribute.bind(elems.time, 'value'),
-          elems.date.getAttribute.bind(elems.date, 'value')
+          elems.date.getAttribute.bind(elems.date, 'value'),
+          elems.noType.getAttribute.bind(elems.noType, 'value')
         ], function(err, results) {
           assert.equal(results[0], 'Some text', 'Correct text input value');
           assert.equal(
@@ -172,6 +209,11 @@ suite('Marionette Forms plugin', function() {
           );
           assert.equal(results[2], '03:04:05', 'Correct time input value');
           assert.equal(results[3], '1997-01-02', 'Correct date input value');
+          assert.equal(
+            results[4],
+            'Lorem Ipsum',
+            'Correct input value even if missing [type]'
+          );
         });
       });
     });


### PR DESCRIPTION
I thought error was caused by empty `[type]` initially (since error message was on `type.trim()`) that's why I added tests for inputs with missing `[type]`.

I believe this change will make errors easier to spot. I spent a good time trying to figure out why my tests was failing - it was caused by trying to set the value of an element that didn't existed on the document.
